### PR TITLE
Custom Format Implementing Format Interface

### DIFF
--- a/src/Keywords/FormatKeyword.php
+++ b/src/Keywords/FormatKeyword.php
@@ -56,7 +56,7 @@ class FormatKeyword implements Keyword
         }
 
         $format = $this->types[$type];
-        if ($type instanceof Format) {
+        if ($format instanceof Format) {
             $ok = $format->validate($context->currentData());
         } else {
             $ok = $format($context->currentData());


### PR DESCRIPTION
Replicate:
```
$myFormat = new class() implements \Opis\JsonSchema\Format {
    public function validate($data): bool
    {
        return $data === 'some-string';
    }
};

$validator = new Validator();
$formats = $validator->parser()->getFormatResolver();
$formats->register('string', 'my-format', $myFormat);

$schema = \Opis\JsonSchema\Helper::toJson(['type' => 'string', 'format' => 'my-format']);
$data = 'my-format';
$validator->validate($data, $schema);
```
This will throw an exception `PHP Fatal error:  Uncaught Error: Function name must be a string`